### PR TITLE
Bump version after package fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rdohms/github-label-syncer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI Command that creates GitHub Labels from a set of configuration",
   "keywords": ["github", "labels", "syncer"],
   "main": "cli.js",


### PR DESCRIPTION
Since npm does not allow re-deploying a version, we need to bump to get
the changes in.